### PR TITLE
Added syntax highlighting for the shebang line

### DIFF
--- a/syntax/dart.vim
+++ b/syntax/dart.vim
@@ -70,6 +70,7 @@ syntax keyword dartTodo          contained TODO FIXME XXX
 syntax region  dartComment       start="/\*"  end="\*/" contains=dartComment,dartTodo,dartDocLink,@Spell
 syntax match   dartLineComment   "//.*" contains=dartTodo,@Spell
 syntax match   dartLineDocComment "///.*" contains=dartTodo,dartDocLink,@Spell
+syntax match   dartShebangLine   /^\%1l#!.*/
 syntax region  dartDocLink       oneline contained start=+\[+ end=+\]+
 
 " Strings
@@ -108,6 +109,7 @@ highlight default link dartOperator        Operator
 highlight default link dartComment         Comment
 highlight default link dartLineComment     Comment
 highlight default link dartLineDocComment  Comment
+highlight default link dartShebangLine     Comment
 highlight default link dartConstant        Constant
 highlight default link dartTypedef         Typedef
 highlight default link dartTodo            Todo


### PR DESCRIPTION
Current syntax highlighting is not coloring the shebang line properly:

```
#!/usr/bin/dart
```

Added a change that would paint the first line as a comment if it starts with "#!".